### PR TITLE
Fixed bad package name in libcthreads.pc.

### DIFF
--- a/libcthreads.pc.in
+++ b/libcthreads.pc.in
@@ -3,7 +3,7 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libuna
+Name: libcthreads
 Description: Library to support cross-platform C threads functions
 Version: @VERSION@
 Libs: -L${libdir} -lcthreads


### PR DESCRIPTION
libcthreads.pc.in erroneously claims that the package is named "libuna".
